### PR TITLE
use an up to date endpoint for group owner creation

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -1145,9 +1145,7 @@ class DiscourseClient(object):
             JSON API response
 
         """
-        return self._put(
-            "/admin/groups/{0}/owners.json".format(groupid), **{"group[usernames]": username}
-        )
+        return self.add_group_owners(groupid, [username])
 
     def add_group_owners(self, groupid, usernames):
         """
@@ -1163,7 +1161,7 @@ class DiscourseClient(object):
         """
         usernames = ",".join(usernames)
         return self._put(
-            "/admin/groups/{0}/owners.json".format(groupid), **{"group[usernames]": usernames}
+            "/groups/{0}/owners.json".format(groupid), **{"usernames": usernames}
         )
 
     def delete_group_owner(self, groupid, userid):


### PR DESCRIPTION
### Summary of changes

Update implementation of adding a single or multiple group owners following [the source code](https://github.com/discourse/discourse/blob/0bd64788d2b4680c04fbef76314a24884d65fed9/app/assets/javascripts/discourse/app/models/group.js#L151-L154)

Closes #76

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
