### PR TITLE
Fix group membership admin functionality

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -1215,7 +1215,7 @@ class DiscourseClient(object):
 
         """
         return self._put(
-            "/admin/groups/{0}/members.json".format(groupid), usernames=username
+            "/groups/{0}/members.json".format(groupid), usernames=username
         )
 
     def add_group_members(self, groupid, usernames):
@@ -1235,7 +1235,8 @@ class DiscourseClient(object):
         """
         usernames = ",".join(usernames)
         return self._put(
-            "/admin/groups/{0}/members.json".format(groupid), usernames=usernames
+            "/groups/{0}/members.json".format(groupid), usernames=usernames,
+            json=True,
         )
 
     def add_user_to_group(self, groupid, userid):
@@ -1255,7 +1256,7 @@ class DiscourseClient(object):
         """
         return self._post("/admin/users/{0}/groups".format(userid), group_id=groupid)
 
-    def delete_group_member(self, groupid, userid):
+    def delete_group_member(self, groupid, username):
         """
         Deletes a member from a group by user ID
 
@@ -1263,15 +1264,16 @@ class DiscourseClient(object):
 
         Args:
             groupid: the ID of the group
-            userid: the ID of the user
+            username: the user name of the user
 
         Returns:
             JSON API response
 
         """
-        return self._delete(
-            "/admin/groups/{0}/members.json".format(groupid), user_id=userid
-        )
+        return self._request(
+            DELETE, "/groups/{0}/members.json".format(groupid),
+            json={"usernames": username})
+
 
     def color_schemes(self, **kwargs):
         """


### PR DESCRIPTION
### Summary of changes

Change the URLs and delete request to match API docs, see:
- https://docs.discourse.org/#tag/Groups/operation/addGroupMembers
- https://docs.discourse.org/#tag/Groups/operation/removeGroupMembers

Note that group member removal is currently affected by https://github.com/discourse/discourse/pull/23042.

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
