### PR TITLE
Add a wrapper for the /posts/by_number endpoint

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -648,6 +648,19 @@ class DiscourseClient:
         """
         return self._get(f"/posts/{post_id}.json", **kwargs)
 
+    def post_by_number(self, topic_id, post_number, **kwargs):
+        """
+        Get a post from its number inside a specific topic
+        Args:
+            topic_id: the topic the post belongs to
+            post_number: the number of the post inside the topic
+            **kwargs:
+
+        Returns:
+            post
+        """
+        return self._get(f"/posts/by_number/{topic_id}/{post_number}", **kwargs)
+
     def posts(self, topic_id, post_ids=None, **kwargs):
         """
         Get a set of posts from a topic

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -180,6 +180,15 @@ class TestEverything:
         discourse_client.latest_posts(before=54321)
         assert request.called_once
 
+    def test_post_by_number(self, discourse_client, requests_mock):
+        request = requests_mock.get(
+            f"{discourse_client.host}/posts/by_number/8796/5",
+            headers={"Content-Type": "application/json; charset=utf-8"},
+            json={},
+        )
+        discourse_client.post_by_number(8796, 5)
+        assert request.called_once
+
     def test_search(self, discourse_client, requests_mock):
         request = requests_mock.get(
             f"{discourse_client.host}/search.json?term=needle",


### PR DESCRIPTION
### Summary of changes

Add a wrapper for the `/posts/by_number` endpoint. This endpoint seems undocumented, but it parallels the way share URLs for a specific post are created: it allows retrieving a post by referencing its creation number inside the topic it belongs to, instead of its global `post_id`.

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
