### PR TITLE
add about endpoint for site statistics

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -1500,6 +1500,12 @@ class DiscourseClient:
         """
         return self._post(f"/category/{category_id}/notifications", **kwargs)
 
+    def about(self):
+        """
+        Get site info
+        """
+        return self._get("/about.json")
+
     def _get(self, path, override_request_kwargs=None, **kwargs):
         """
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -205,3 +205,10 @@ class TestBadges:
 
         assert request_payload["username"] == ["username"]
         assert request_payload["badge_id"] == ["1"]
+
+
+class TestAbout:
+    def test_about(self, discourse_client, discourse_request):
+        request = discourse_request("get", "/about.json")
+        discourse_client.about()
+        assert request.called_once


### PR DESCRIPTION
Hello there!

### Summary of changes

This PR simply add the `about` endpoint for discourse instance statistic like total post number, etc.

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
