### PR TITLE
fix: search term moved to q

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -844,17 +844,17 @@ class DiscourseClient:
         kwargs = {"email": user_email, "topic_id": topic_id}
         return self._post(f"/t/{topic_id}/invite.json", **kwargs)
 
-    def search(self, term, **kwargs):
+    def search(self, q, **kwargs):
         """
 
         Args:
-            term:
+            q:
             **kwargs:
 
         Returns:
 
         """
-        kwargs["term"] = term
+        kwargs["q"] = q
         return self._get("/search.json", **kwargs)
 
     def badges(self, **kwargs):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -166,8 +166,8 @@ class TestPosts:
 
 class TestSearch:
     def test_search(self, discourse_client, discourse_request):
-        request = discourse_request("get", "/search.json?term=needle")
-        discourse_client.search(term="needle")
+        request = discourse_request("get", "/search.json?q=needle")
+        discourse_client.search(q="needle")
         assert request.called_once
 
 


### PR DESCRIPTION
### Summary of changes

Discourse search api use `q` and not `term` https://docs.discourse.org/#tag/Search/operation/search . 

I do not know for how long it is broken or if it is only for recent discourse version, but this is possible breaking change for pydiscourse.

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
