### PR TITLE
Add missing private message endpoints

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -528,6 +528,20 @@ class DiscourseClient:
             **kwargs,
         )
 
+    def private_messages_sent(self, username=None, **kwargs):
+        """
+
+        Args:
+            username:
+            **kwargs:
+
+        Returns:
+
+        """
+        if username is None:
+            username = self.api_username
+        return self._get(f"/topics/private-messages-sent/{username}.json", **kwargs)
+
     def category_topics(self, category_id, **kwargs):
         """
         Returns a list of all topics in a category.

--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -542,6 +542,33 @@ class DiscourseClient:
             username = self.api_username
         return self._get(f"/topics/private-messages-sent/{username}.json", **kwargs)
 
+    def send_private_message(
+            self,
+            content,
+            title,
+            target_usernames,
+            **kwargs,
+    ):
+        """
+
+        Args:
+            content:
+            title:
+            target_usernames:
+            **kwargs:
+
+        Returns:
+
+        """
+        return self._post(
+            "/posts",
+            raw=content,
+            title=title,
+            target_recipients=target_usernames,
+            archetype="private_message",
+            **kwargs,
+        )
+
     def category_topics(self, category_id, **kwargs):
         """
         Returns a list of all topics in a category.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -130,6 +130,11 @@ class TestPrivateMessages:
         discourse_client.private_messages_sent("myusername")
         assert request.called_once
 
+    def test_send_private_message(self, discourse_client, discourse_request):
+        request = discourse_request("post", "/posts")
+        discourse_client.send_private_message("content", "title", "username")
+        assert request.called_once
+
 class TestTopics:
     def test_hot_topics(self, discourse_client, discourse_request):
         request = discourse_request("get", "/hot.json")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -114,6 +114,21 @@ class TestUserManagement:
 
         assert request.called_once
 
+class TestPrivateMessages:
+    def test_private_messages(self, discourse_client, discourse_request):
+        request = discourse_request("get", "/topics/private-messages/myusername.json")
+        discourse_client.private_messages("myusername")
+        assert request.called_once
+
+    def test_private_messages_unread(self, discourse_client, discourse_request):
+        request = discourse_request("get", "/topics/private-messages-unread/myusername.json")
+        discourse_client.private_messages_unread("myusername")
+        assert request.called_once
+
+    def test_private_messages_sent(self, discourse_client, discourse_request):
+        request = discourse_request("get", "/topics/private-messages-sent/myusername.json")
+        discourse_client.private_messages_sent("myusername")
+        assert request.called_once
 
 class TestTopics:
     def test_hot_topics(self, discourse_client, discourse_request):


### PR DESCRIPTION
### Summary of changes

This PR adds functions to send private messages and get private messages sent by a user

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
