### PR TITLE
Closes #41: add function to get all posts in a topic

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -737,6 +737,26 @@ class DiscourseClient:
         """
         return self._get(f"/t/{topic_id}/posts.json", **kwargs)
 
+    def topic_all_posts(self, topic_id, **kwargs):
+        """
+
+        Args:
+            topic_id:
+            **kwargs:
+
+        Returns:
+
+        """
+        topic = self._get(f"/t/{topic_id}.json", **kwargs)
+        trunc = int(topic["posts_count"] / 20)
+        num_pages = trunc if (topic["posts_count"] % 20 == 0) else trunc + 1
+        for i in range(2, num_pages + 1):
+            page = self._get(f"/t/{topic_id}.json?page={str(i)}", **kwargs)
+            topic["post_stream"]["posts"] = (
+                    topic["post_stream"]["posts"] + page["post_stream"]["posts"]
+            )
+        return topic
+
     def update_topic(self, topic_url, title, **kwargs):
         """
         Update a topic


### PR DESCRIPTION
### Summary of changes

By default, discourse only includes the first 20 posts in a topic. This PR adds a new function that iterates using the 'page' query parameter to obtain all the posts available

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
