### PR TITLE
add new function to get topic without slug

### DIFF
--- a/src/pydiscourse/client.py
+++ b/src/pydiscourse/client.py
@@ -602,6 +602,18 @@ class DiscourseClient:
         """
         return self._get(f"/t/{slug}/{topic_id}.json", **kwargs)
 
+    def topic_by_id(self, topic_id, **kwargs):
+        """
+
+        Args:
+            topic_id:
+            **kwargs:
+
+        Returns:
+
+        """
+        return self._get(f"/t/{topic_id}.json", **kwargs)
+
     def delete_topic(self, topic_id, **kwargs):
         """
         Remove a topic


### PR DESCRIPTION
### Summary of changes

Existent client.topic() function gets a topic providing the slug and the topic_id as arguments. This PR proposes a new function 'topic_by_id'  to get the topic only by providing the topic_id. 

The reason to create a new function rather than updating the existing 'topic()' is to guarantee backwards compatibility. 

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
