### PR TITLE
Add pypi badge and correct bennylope -> pydiscourse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,9 @@ pydiscourse
    :alt: PyPI
    :target: https://pypi.org/project/pydiscourse/
 
-.. image:: https://github.com/bennylope/pydiscourse/workflows/Tests/badge.svg
+.. image:: https://github.com/pydiscourse/pydiscourse/workflows/Tests/badge.svg
     :alt: Build Status
-    :target: https://github.com/bennylope/pydiscourse/actions
+    :target: https://github.com/pydiscourse/pydiscourse/actions
 
 .. image:: https://img.shields.io/badge/Check%20out%20the-Docs-blue.svg
     :alt: Check out the Docs

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,10 @@
 pydiscourse
 ===========
 
+.. image:: https://img.shields.io/pypi/v/pydiscourse?color=blue
+   :alt: PyPI
+   :target: https://pypi.org/project/pydiscourse/
+
 .. image:: https://github.com/bennylope/pydiscourse/workflows/Tests/badge.svg
     :alt: Build Status
     :target: https://github.com/bennylope/pydiscourse/actions


### PR DESCRIPTION
### Summary of changes

Simply add the pypi badge for people who want to directly go to pypi and see the last version.

## Checklist

- [x] Changes represent a *discrete update*
- [x] Commit messages are meaningful and descriptive
- [x] Changeset does not include any extraneous changes unrelated to the discrete change
